### PR TITLE
Implement useGoogleLogin `auth-code` flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,21 @@ Head over to https://console.developers.google.com/apis/credentials and sign in 
 - From the "Credentials" page, click "+ Create Credentials", then "OAuth client ID"
   - Select Application Type: "Web Application"
   - Add Authorized Javascript Origins: http://localhost, http://localhost:3000, https://example.com (prod domain must be HTTPS)
+  - If using custom button, add the same origins to "Authorized redirect URIs"
   - Click "Save"
-- Copy the OAuth "Client ID" and save it for later. Mine looks like 309209880368-4uqd9e44h7t4alhhdqn48pvvr63cc5j5.apps.googleusercontent.com
+- Copy the OAuth "Client ID" and "Client Secret" and save it for later. Mine looks like 309209880368-4uqd9e44h7t4alhhdqn48pvvr63cc5j5.apps.googleusercontent.com
 
 https://github.com/reflex-dev/reflex-examples/assets/1524005/af2499a6-0bda-4d60-b52b-4f51b7322fd5
+
+### Configure Environment Variables
+
+Set the following environment variables based on your deployment.
+
+```bash
+export GOOGLE_CLIENT_ID="309209880368-4uqd9e44h7t4alhhdqn48pvvr63cc5j5.apps.googleusercontent.com"
+export GOOGLE_CLIENT_SECRET="your_client_secret"
+export GOOGLE_REDIRECT_URI="http://localhost:3000"
+```
 
 ### Integrate with Reflex app
 
@@ -72,3 +83,30 @@ See the example in
 [masenf/rx_shout](https://github.com/masenf/rx_shout/blob/main/rx_shout/state.py)
 for how to integrate an authenticated Google user with other app-specific user
 data.
+
+### Customizing the Button
+
+If you want to use your own login button, you may use whatever component you
+like, as long as it is wrapped in a `reflex_google_auth.google_oauth_provider`
+component and the `on_click` triggers
+`reflex_google_auth.handle_google_login()`. Note that this cannot be combined
+with other event handlers.
+
+This functionality is also exposed in the `require_google_auth` decorator, which
+accepts a `button` keyword argument.
+
+When using a custom button, the returned auth-code _must be validated on the
+backend_, which is handled by this library, but **requires additionally setting
+`GOOGLE_CLIENT_SECRET` and `GOOGLE_REDIRECT_URI` environment variables**. These
+can be configured in the Google Cloud Console as described above.
+
+```python
+from reflex_google_auth import handle_google_login, require_google_login, GoogleAuthState
+
+
+@require_google_login(button=rx.button("Google Login 🚀", on_click=handle_google_login()))
+def custom_button() -> rx.Component:
+    return rx.vstack(
+        f"{GoogleAuthState.tokeninfo['email']} clicked a custom button to login, nice",
+    )
+```

--- a/custom_components/reflex_google_auth/__init__.py
+++ b/custom_components/reflex_google_auth/__init__.py
@@ -1,11 +1,12 @@
 from .decorator import require_google_login
-from .google_auth import google_login, google_oauth_provider
+from .google_auth import google_login, google_oauth_provider, handle_google_login
 from .state import GoogleAuthState, set_client_id
 
 __all__ = [
     "GoogleAuthState",
     "google_oauth_provider",
     "google_login",
+    "handle_google_login",
     "set_client_id",
     "require_google_login",
 ]

--- a/custom_components/reflex_google_auth/decorator.py
+++ b/custom_components/reflex_google_auth/decorator.py
@@ -1,4 +1,5 @@
 import functools
+from typing import Callable, overload
 
 import reflex as rx
 
@@ -6,20 +7,64 @@ from . import google_auth
 from .state import GoogleAuthState
 
 
-def require_google_login(page) -> rx.Component:
-    @functools.wraps(page)
-    def _auth_wrapper() -> rx.Component:
-        return google_auth.google_oauth_provider(
-            rx.cond(
-                rx.State.is_hydrated,
+ComponentCallable = Callable[[], rx.Component]
+
+
+@overload
+def require_google_login(
+    page: ComponentCallable,
+) -> ComponentCallable: ...
+
+
+@overload
+def require_google_login() -> Callable[[ComponentCallable], ComponentCallable]: ...
+
+
+@overload
+def require_google_login(
+    *,
+    button: rx.Component | None,
+) -> Callable[[ComponentCallable], ComponentCallable]: ...
+
+
+def require_google_login(
+    page: ComponentCallable | None = None,
+    *,
+    button: rx.Component | None = None,
+) -> ComponentCallable | Callable[[ComponentCallable], ComponentCallable]:
+    """Decorator to require Google login before rendering a page.
+
+    The login button should have on_click set to `reflex_google_auth.handle_google_login`.
+
+    Args:
+        page: Page to render after Google login.
+        button: Button to render if Google login is required.
+
+    Returns:
+        A decorator function or the decorated page.
+    """
+
+    if button is None:
+        button = google_auth.google_login()
+
+    def _inner(page: Callable[[], rx.Component]) -> Callable[[], rx.Component]:
+        @functools.wraps(page)
+        def _auth_wrapper() -> rx.Component:
+            return google_auth.google_oauth_provider(
                 rx.cond(
-                    GoogleAuthState.token_is_valid,
-                    page(),
-                    google_auth.google_login(),
+                    rx.State.is_hydrated,
+                    rx.cond(
+                        GoogleAuthState.token_is_valid,
+                        page(),
+                        button,
+                    ),
                 ),
-            ),
-        )
+            )
 
-    _auth_wrapper.__name__ = page.__name__
+        _auth_wrapper.__name__ = page.__name__
 
-    return _auth_wrapper
+        return _auth_wrapper
+
+    if page is None:
+        return _inner
+    return _inner(page=page)

--- a/custom_components/reflex_google_auth/google_auth.py
+++ b/custom_components/reflex_google_auth/google_auth.py
@@ -1,10 +1,15 @@
+from typing import cast
 import reflex as rx
+from reflex.event import EventType, BASE_STATE
 
 from .state import GoogleAuthState
 
 
+LIBRARY = "@react-oauth/google"
+
+
 class GoogleOAuthProvider(rx.Component):
-    library = "@react-oauth/google"
+    library = LIBRARY
     tag = "GoogleOAuthProvider"
 
     client_id: rx.Var[str]
@@ -19,11 +24,11 @@ google_oauth_provider = GoogleOAuthProvider.create
 
 
 def _on_success_signature(data: rx.Var[dict]) -> tuple[rx.Var[dict]]:
-    return data,
+    return (data,)
 
 
 class GoogleLogin(rx.Component):
-    library = "@react-oauth/google"
+    library = LIBRARY
     tag = "GoogleLogin"
 
     on_success: rx.EventHandler[_on_success_signature]
@@ -31,7 +36,35 @@ class GoogleLogin(rx.Component):
     @classmethod
     def create(cls, **props) -> "GoogleLogin":
         props.setdefault("on_success", GoogleAuthState.on_success)
-        return super().create(**props)
+        return cast("GoogleLogin", super().create(**props))
 
 
 google_login = GoogleLogin.create
+
+
+def handle_google_login(
+    on_success: EventType[[dict], BASE_STATE] = GoogleAuthState.on_success,
+) -> rx.Var[rx.EventChain]:
+    on_success_event_chain = rx.Var.create(
+        # TODO: rx.EventChain.create(
+        rx.Component()._create_event_chain(
+            value=on_success,  # type: ignore
+            args_spec=_on_success_signature,
+            key="on_success",
+        )
+    )
+    return rx.Var(
+        "() => login()",
+        _var_type=rx.EventChain,
+        _var_data=rx.vars.VarData(
+            hooks={
+                """
+const login = useGoogleLogin({
+  onSuccess: %s,
+  flow: 'auth-code',
+});"""
+                % on_success_event_chain: None,
+            },
+            imports={LIBRARY: "useGoogleLogin"},
+        ).merge(on_success_event_chain._get_all_var_data()),
+    )

--- a/custom_components/reflex_google_auth/state.py
+++ b/custom_components/reflex_google_auth/state.py
@@ -6,11 +6,15 @@ import time
 
 from google.auth.transport import requests
 from google.oauth2.id_token import verify_oauth2_token
+from httpx import AsyncClient
 
 import reflex as rx
 
 
-CLIENT_ID = None
+TOKEN_URI = "https://oauth2.googleapis.com/token"
+CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID", "")
+CLIENT_SECRET = os.environ.get("GOOGLE_CLIENT_SECRET", "")
+REDIRECT_URI = os.environ.get("GOOGLE_REDIRECT_URI", "")
 
 
 def set_client_id(client_id: str):
@@ -19,10 +23,39 @@ def set_client_id(client_id: str):
     CLIENT_ID = client_id
 
 
+async def get_id_token(auth_code) -> str:
+    """Get the id token credential from an auth code.
+
+    Args:
+        auth_code: Returned from an 'auth-code' flow.
+
+    Returns:
+        The id token credential.
+    """
+    async with AsyncClient() as client:
+        response = await client.post(
+            TOKEN_URI,
+            data={
+                "code": auth_code,
+                "client_id": CLIENT_ID,
+                "client_secret": CLIENT_SECRET,
+                "redirect_uri": REDIRECT_URI,
+                "grant_type": "authorization_code",
+            },
+        )
+        response.raise_for_status()
+        response_data = response.json()
+        return response_data.get("id_token")
+
+
 class GoogleAuthState(rx.State):
     id_token_json: str = rx.LocalStorage()
 
-    def on_success(self, id_token: dict):
+    @rx.event
+    async def on_success(self, id_token: dict):
+        if "code" in id_token:
+            # Handle auth-code flow
+            id_token["credential"] = await get_id_token(id_token["code"])
         self.id_token_json = json.dumps(id_token)
 
     @rx.var(cache=True)
@@ -39,9 +72,11 @@ class GoogleAuthState(rx.State):
             )
         except Exception as exc:
             if self.id_token_json:
-                print(f"Error verifying token: {exc}")
+                print(f"Error verifying token: {exc!r}")
+                self.id_token_json = ""
         return {}
 
+    @rx.event
     def logout(self):
         self.id_token_json = ""
 

--- a/google_auth_demo/google_auth_demo/google_auth_demo.py
+++ b/google_auth_demo/google_auth_demo/google_auth_demo.py
@@ -1,6 +1,10 @@
 import reflex as rx
 
-from reflex_google_auth import GoogleAuthState, require_google_login
+from reflex_google_auth import (
+    GoogleAuthState,
+    handle_google_login,
+    require_google_login,
+)
 
 
 class State(GoogleAuthState):
@@ -11,7 +15,7 @@ class State(GoogleAuthState):
         return "Not logged in."
 
 
-def user_info(tokeninfo: dict) -> rx.Component:
+def user_info(tokeninfo: rx.vars.ObjectVar) -> rx.Component:
     return rx.hstack(
         rx.avatar(
             src=tokeninfo["picture"],
@@ -33,6 +37,7 @@ def index():
         rx.heading("Google OAuth", size="8"),
         rx.link("Protected Page", href="/protected"),
         rx.link("Partially Protected Page", href="/partially-protected"),
+        rx.link("Custom Login Button", href="/custom-button"),
         align="center",
     )
 
@@ -48,7 +53,7 @@ def protected() -> rx.Component:
 
 
 @require_google_login
-def user_name_or_sign_in():
+def user_name_or_sign_in() -> rx.Component:
     return rx.heading(GoogleAuthState.tokeninfo["name"], size="6")
 
 
@@ -61,7 +66,18 @@ def partially_protected() -> rx.Component:
             "you will see a sign in button",
         ),
         user_name_or_sign_in(),
-    ),
+    )
+
+
+@rx.page(route="/custom-button")
+@require_google_login(
+    button=rx.button("Google Login 🚀", on_click=handle_google_login())
+)
+def custom_button() -> rx.Component:
+    return rx.vstack(
+        user_info(GoogleAuthState.tokeninfo),
+        "You clicked a custom button to login, nice",
+    )
 
 
 app = rx.App()

--- a/google_auth_demo/requirements.txt
+++ b/google_auth_demo/requirements.txt
@@ -1,2 +1,2 @@
-reflex>=0.4.3
+reflex>=0.6.6
 reflex-google-auth

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reflex-google-auth"
-version = "0.0.7"
+version = "0.0.8"
 description = "Sign in with Google"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -16,7 +16,7 @@ authors = [{ name = "Masen Furer", email = "m_github@0x26.net" }]
 keywords = ["reflex", "reflex-custom-components"]
 
 dependencies = [
-    "reflex>=0.4.6",
+    "reflex>=0.6.6",
     "google-auth[requests]",
 ]
 


### PR DESCRIPTION
This flow allows custom components to be used when triggering the Sign In With Google box, but it requires additional validation of the returned "code" value, which requires a client secret and a redirect uri. So it is slightly more complicated, but more flexible.

Improve type hinting.

Update README.

Bump minimum Reflex to 0.6.6