### PR TITLE
Expose tokeninfo as TypedDict

### DIFF
--- a/custom_components/reflex_google_auth/state.py
+++ b/custom_components/reflex_google_auth/state.py
@@ -3,6 +3,7 @@
 import json
 import os
 import time
+from typing import TypedDict
 
 import reflex as rx
 from google.auth.transport import requests
@@ -19,6 +20,24 @@ def set_client_id(client_id: str):
     """Set the client id."""
     global CLIENT_ID
     CLIENT_ID = client_id
+
+
+class TokenCredential(TypedDict, total=False):
+    iss: str
+    azp: str
+    aud: str
+    sub: str
+    hd: str
+    email: str
+    email_verified: bool
+    nbf: int
+    name: str
+    picture: str
+    given_name: str
+    family_name: str
+    iat: int
+    exp: int
+    jti: str
 
 
 async def get_id_token(auth_code) -> str:
@@ -61,7 +80,7 @@ class GoogleAuthState(rx.State):
         return CLIENT_ID or os.environ.get("GOOGLE_CLIENT_ID", "")
 
     @rx.var(cache=True)
-    def tokeninfo(self) -> dict[str, str]:
+    def tokeninfo(self) -> TokenCredential:
         try:
             return verify_oauth2_token(
                 json.loads(self.id_token_json)["credential"],

--- a/google_auth_demo/google_auth_demo/google_auth_demo.py
+++ b/google_auth_demo/google_auth_demo/google_auth_demo.py
@@ -10,7 +10,7 @@ class State(GoogleAuthState):
     @rx.var(cache=True)
     def protected_content(self) -> str:
         if self.token_is_valid:
-            return f"This content can only be viewed by a logged in User. Nice to see you {self.tokeninfo['name']}"
+            return f"This content can only be viewed by a logged in User. Nice to see you {self.tokeninfo.get('name')}"
         return "Not logged in."
 
 


### PR DESCRIPTION
This allows the fields of the tokeninfo to be understood as correctly typed Reflex Vars