### PR TITLE
ENG-7795: plumb through `scopes` parameter to get access_token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,6 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.12"
-      - name: Install package
-        run: pip install .
       - name: Publish to PyPI
         if: ${{ env.HAS_PYPI_TOKEN == 'true' }}
         run: uv build && uv publish -u __token__ -p ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,15 +15,15 @@ jobs:
       HAS_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN != '' }}
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v3
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.12"
       - name: Install package
         run: pip install .
       - name: Publish to PyPI
         if: ${{ env.HAS_PYPI_TOKEN == 'true' }}
-        run: reflex component publish -t ${{ secrets.PYPI_TOKEN }} --no-share --no-validate-project-info
+        run: uv build && uv publish -u __token__ -p ${{ secrets.PYPI_TOKEN }}
   deploy:
     name: Deploy Demo App to Reflex Cloud
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -110,3 +110,18 @@ def custom_button() -> rx.Component:
         f"{GoogleAuthState.tokeninfo['email']} clicked a custom button to login, nice",
     )
 ```
+
+### Requesting Scopes
+
+By default, only the basic profile scopes are requested. To request additional
+scopes for accessing other Google APIs in the context of the authenticated user:
+
+1. Update your app registration in the Google Cloud Console to add the additional scopes
+   you want to request.
+2. Pass the `scope` parameter to `handle_google_login` event handler. NOTE:
+   scopes can only be requested with the `auth-code` flow, so you must set
+   `GOOGLE_CLIENT_SECRET` and `GOOGLE_REDIRECT_URI` environment variables as
+   described above.
+
+See the `custom_scope` example in `google_auth_demo.py` for how to request
+Drive scopes and and then use Google Drive API to store and retrieve app data.

--- a/custom_components/reflex_google_auth/google_auth.py
+++ b/custom_components/reflex_google_auth/google_auth.py
@@ -43,8 +43,18 @@ google_login = GoogleLogin.create
 
 
 def handle_google_login(
+    scope: str | list[str] | rx.Var[str] | rx.Var[list[str]] = "openid profile email",
     on_success: EventType[dict] = GoogleAuthState.on_success,
 ) -> rx.Var[rx.EventChain]:
+    """Create a login event chain to handle Google login.
+
+    Args:
+        scope: The space-separated OAuth scopes to request (default "openid profile email").
+        on_success: The event to call on successful login (default GoogleAuthState.on_success).
+
+    Returns:
+        An event chain that handles the login process.
+    """
     on_success_event_chain = rx.Var.create(
         rx.EventChain.create(
             value=on_success,  # type: ignore
@@ -52,6 +62,9 @@ def handle_google_login(
             key="on_success",
         )
     )
+    scope = rx.Var.create(scope) if not isinstance(scope, rx.Var) else scope
+    if isinstance(scope, rx.vars.ArrayVar):
+        scope = scope.join(" ")
     return rx.Var(
         "() => login()",
         _var_type=rx.EventChain,
@@ -61,8 +74,12 @@ def handle_google_login(
 const login = useGoogleLogin({
   onSuccess: %s,
   flow: 'auth-code',
+  scope: %s,
 });"""
-                % on_success_event_chain: on_success_event_chain._get_all_var_data(),
+                % (on_success_event_chain, scope): rx.vars.VarData.merge(
+                    on_success_event_chain._get_all_var_data(),
+                    scope._get_all_var_data(),
+                ),
             },
             imports={LIBRARY: "useGoogleLogin"},
         ),

--- a/custom_components/reflex_google_auth/state.py
+++ b/custom_components/reflex_google_auth/state.py
@@ -90,7 +90,9 @@ class GoogleAuthState(rx.State):
     def id_token_json(self) -> str:
         """For compatibility only. Use token_response_json instead."""
         try:
-            return json.dumps({"credential": json.loads(self.token_response_json).get("id_token", "")})
+            return json.dumps(
+                {"credential": json.loads(self.token_response_json).get("id_token", "")}
+            )
         except Exception:
             return ""
 

--- a/custom_components/reflex_google_auth/state.py
+++ b/custom_components/reflex_google_auth/state.py
@@ -22,6 +22,15 @@ def set_client_id(client_id: str):
     CLIENT_ID = client_id
 
 
+class TokenResponse(TypedDict, total=False):
+    access_token: str
+    expires_in: int
+    refresh_token: str
+    scope: str
+    token_type: str
+    id_token: str
+
+
 class TokenCredential(TypedDict, total=False):
     iss: str
     azp: str
@@ -30,6 +39,7 @@ class TokenCredential(TypedDict, total=False):
     hd: str
     email: str
     email_verified: bool
+    at_hash: str
     nbf: int
     name: str
     picture: str
@@ -40,14 +50,14 @@ class TokenCredential(TypedDict, total=False):
     jti: str
 
 
-async def get_id_token(auth_code) -> str:
-    """Get the id token credential from an auth code.
+async def get_token(auth_code) -> TokenResponse:
+    """Get the token(s) from an auth code.
 
     Args:
         auth_code: Returned from an 'auth-code' flow.
 
     Returns:
-        The id token credential.
+        The token response, containing access_token, refresh_token and id_token.
     """
     async with AsyncClient() as client:
         response = await client.post(
@@ -62,40 +72,119 @@ async def get_id_token(auth_code) -> str:
         )
         response.raise_for_status()
         response_data = response.json()
-        return response_data.get("id_token")
+        return TokenResponse(response_data)
+
+
+async def get_id_token(auth_code: str) -> str:
+    token_data = await get_token(auth_code)
+    if "id_token" not in token_data:
+        raise ValueError("No id_token in token response")
+    return token_data["id_token"]
 
 
 class GoogleAuthState(rx.State):
-    id_token_json: str = rx.LocalStorage()
+    token_response_json: str = rx.LocalStorage()
+    refresh_token: str = rx.LocalStorage()
+
+    @rx.var
+    def id_token_json(self) -> str:
+        """For compatibility only. Use token_response_json instead."""
+        try:
+            return json.dumps({"credential": json.loads(self.token_response_json).get("id_token", "")})
+        except Exception:
+            return ""
 
     @rx.event
-    async def on_success(self, id_token: dict):
-        if "code" in id_token:
+    async def on_success(self, response: dict):
+        if "code" in response:
             # Handle auth-code flow
-            id_token["credential"] = await get_id_token(id_token["code"])
-        self.id_token_json = json.dumps(id_token)
+            token_response = await get_token(response["code"])
+            self.token_response_json = json.dumps(token_response)
+            if "refresh_token" in token_response:
+                self.refresh_token = token_response["refresh_token"]
+        elif "credential" in response:
+            # Handle id-token flow
+            self.token_response_json = json.dumps({"id_token": response["credential"]})
+            self.refresh_token = ""
+        else:
+            self.token_response_json = ""
+            self.refresh_token = ""
+            raise ValueError("No code or credential in response")
+
+    @rx.event
+    async def refresh_access_token(self):
+        try:
+            if not self.access_token:
+                return  # no token to refresh
+            if not self.refresh_token:
+                # token not available, must re-auth
+                self.token_response_json = ""
+                return
+            async with AsyncClient() as client:
+                response = await client.post(
+                    TOKEN_URI,
+                    data={
+                        "client_id": CLIENT_ID,
+                        "client_secret": CLIENT_SECRET,
+                        "refresh_token": self.refresh_token,
+                        "grant_type": "refresh_token",
+                    },
+                )
+                response.raise_for_status()
+                new_token_data = response.json()
+                # Save the new refresh token if provided
+                if "refresh_token" in new_token_data:
+                    self.refresh_token = new_token_data["refresh_token"]
+                self.token_response_json = json.dumps(new_token_data)
+        except Exception as exc:
+            print(f"Error refreshing token: {exc!r}")  # noqa: T201
 
     @rx.var(cache=True)
     def client_id(self) -> str:
         return CLIENT_ID or os.environ.get("GOOGLE_CLIENT_ID", "")
 
+    @rx.var
+    def scopes(self) -> list[str]:
+        try:
+            scope_str = json.loads(self.token_response_json).get("scope", "")
+            return scope_str.split(" ") if scope_str else []
+        except Exception:
+            return []
+
+    @rx.var
+    def access_token(self) -> str:
+        try:
+            return json.loads(self.token_response_json).get("access_token", "")
+        except Exception:
+            return ""
+
+    @rx.var
+    def id_token(self) -> str:
+        try:
+            return json.loads(self.token_response_json).get("id_token", "")
+        except Exception:
+            return ""
+
     @rx.var(cache=True)
     def tokeninfo(self) -> TokenCredential:
         try:
-            return verify_oauth2_token(
-                json.loads(self.id_token_json)["credential"],
-                requests.Request(),
-                self.client_id,
+            return TokenCredential(
+                verify_oauth2_token(
+                    self.id_token,
+                    requests.Request(),
+                    self.client_id,
+                )
             )
         except Exception as exc:
-            if self.id_token_json:
+            if self.token_response_json:
                 print(f"Error verifying token: {exc!r}")  # noqa: T201
-                self.id_token_json = ""
+                self.token_response_json = ""
         return {}
 
     @rx.event
     def logout(self):
-        self.id_token_json = ""
+        self.token_response_json = ""
+        self.refresh_token = ""
 
     @rx.var(cache=False)
     def token_is_valid(self) -> bool:

--- a/google_auth_demo/google_auth_demo/google_auth_demo.py
+++ b/google_auth_demo/google_auth_demo/google_auth_demo.py
@@ -1,4 +1,11 @@
+import io
+import json
+
+import google.oauth2.credentials
 import reflex as rx
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
 from reflex_google_auth import (
     GoogleAuthState,
     handle_google_login,
@@ -37,6 +44,7 @@ def index():
         rx.link("Protected Page", href="/protected"),
         rx.link("Partially Protected Page", href="/partially-protected"),
         rx.link("Custom Login Button", href="/custom-button"),
+        rx.link("Custom Scope", href="/custom-scope"),
         align="center",
     )
 
@@ -76,6 +84,178 @@ def custom_button() -> rx.Component:
     return rx.vstack(
         user_info(GoogleAuthState.tokeninfo),
         "You clicked a custom button to login, nice",
+    )
+
+
+class DriveState(rx.State):
+    app_data: str = ""
+    loading: bool = False
+
+    async def _get_config_json_metadata(self) -> dict[str, str] | None:
+        google_auth_state = await self.get_state(GoogleAuthState)
+        if not google_auth_state.token_is_valid:
+            return None
+        credentials = google.oauth2.credentials.Credentials(
+            google_auth_state.access_token,
+            refresh_token=google_auth_state.refresh_token,
+        )
+        service = build("drive", "v3", credentials=credentials)
+        results = await rx.run_in_thread(
+            service.files()
+            .list(
+                spaces="appDataFolder",
+                fields="nextPageToken, files(id, name)",
+                pageSize=10,
+            )
+            .execute
+        )
+        items = results.get("files", [])
+        if not items:
+            print("No files found.")
+            return None
+        return items[0]
+
+    async def _save_file_to_drive(self, content: str):
+        google_auth_state = await self.get_state(GoogleAuthState)
+        if not google_auth_state.token_is_valid:
+            return
+        credentials = google.oauth2.credentials.Credentials(
+            google_auth_state.access_token,
+            refresh_token=google_auth_state.refresh_token,
+        )
+        payload = {
+            "content": content,
+        }
+        service = build("drive", "v3", credentials=credentials)
+        upload_content = MediaIoBaseUpload(
+            io.BytesIO(json.dumps(payload).encode("utf-8")),
+            mimetype="application/json",
+            resumable=True,
+        )
+
+        existing_file = await self._get_config_json_metadata()
+        if existing_file:
+            file = await rx.run_in_thread(
+                service.files()
+                .update(
+                    fileId=existing_file["id"], media_body=upload_content, fields="id"
+                )
+                .execute
+            )
+        else:
+            file_metadata = {
+                "name": "config.json",
+                "parents": ["appDataFolder"],
+            }
+            file = await rx.run_in_thread(
+                service.files()
+                .create(body=file_metadata, media_body=upload_content, fields="id")
+                .execute
+            )
+        print(f"File ID: {file.get('id')}")
+
+    async def _load_file_from_drive(self) -> str:
+        google_auth_state = await self.get_state(GoogleAuthState)
+        if not google_auth_state.token_is_valid:
+            return ""
+        credentials = google.oauth2.credentials.Credentials(
+            google_auth_state.access_token,
+            refresh_token=google_auth_state.refresh_token,
+        )
+        service = build("drive", "v3", credentials=credentials)
+        existing_file = await self._get_config_json_metadata()
+        if not existing_file:
+            return ""
+        try:
+            # pylint: disable=maybe-no-member
+            request = await rx.run_in_thread(
+                lambda: service.files().get_media(fileId=existing_file["id"])
+            )
+            file = io.BytesIO()
+            downloader = MediaIoBaseDownload(file, request)
+            done = False
+            while done is False:
+                status, done = await rx.run_in_thread(downloader.next_chunk)
+        except HttpError as error:
+            print(f"An error occurred: {error}")
+            file = None
+        if file:
+            file.seek(0)
+            try:
+                payload = json.loads(file.read().decode("utf-8"))
+                return payload.get("content", "")
+            except Exception as exc:
+                print(f"Error reading config file: {exc!r}")  # noqa: T201
+        return ""
+
+    @rx.event
+    async def set_app_data(self, value: str):
+        self.app_data = value
+        self.loading = True
+        yield
+        try:
+            await self._save_file_to_drive(value)
+        finally:
+            self.loading = False
+
+    @rx.event
+    async def on_load(self):
+        self.loading = True
+        yield
+        try:
+            self.app_data = await self._load_file_from_drive()
+        finally:
+            self.loading = False
+
+
+@rx.page(route="/custom-scope", on_load=DriveState.on_load)
+@require_google_login(
+    button=rx.button(
+        "Login with Drive API scope",
+        on_click=handle_google_login(
+            scope=(
+                "https://www.googleapis.com/auth/drive.appdata "
+                "https://www.googleapis.com/auth/drive.file "
+                "https://www.googleapis.com/auth/drive.install "
+            ),
+        ),
+    )
+)
+def custom_scope() -> rx.Component:
+    return rx.vstack(
+        user_info(GoogleAuthState.tokeninfo),
+        rx.vstack(
+            rx.heading("App Data Stored in Drive"),
+            rx.hstack(
+                rx.text_area(
+                    default_value=DriveState.app_data,
+                    key=DriveState.app_data,
+                    on_blur=DriveState.set_app_data,
+                ),
+                rx.cond(
+                    DriveState.loading,
+                    rx.spinner(),
+                    rx.button("Refresh", on_click=DriveState.on_load),
+                ),
+            ),
+            rx.heading("Authorized Scopes"),
+            rx.foreach(
+                GoogleAuthState.scopes,
+                lambda scope: rx.code(scope),
+            ),
+            rx.heading("Raw Access Token"),
+            rx.code(GoogleAuthState.access_token),
+            rx.button("Refresh AT", on_click=GoogleAuthState.refresh_access_token),
+            rx.hstack(
+                "Time until token expiry",
+                rx.moment(
+                    GoogleAuthState.tokeninfo.exp,
+                    unix=True,
+                    duration_from_now=True,
+                    interval=1000,
+                ),
+            ),
+        ),
     )
 
 

--- a/google_auth_demo/google_auth_demo/google_auth_demo.py
+++ b/google_auth_demo/google_auth_demo/google_auth_demo.py
@@ -111,7 +111,7 @@ class DriveState(rx.State):
         )
         items = results.get("files", [])
         if not items:
-            print("No files found.")
+            print("No files found.")  # noqa: T201
             return None
         return items[0]
 
@@ -152,7 +152,7 @@ class DriveState(rx.State):
                 .create(body=file_metadata, media_body=upload_content, fields="id")
                 .execute
             )
-        print(f"File ID: {file.get('id')}")
+        print(f"File ID: {file.get('id')}")  # noqa: T201
 
     async def _load_file_from_drive(self) -> str:
         google_auth_state = await self.get_state(GoogleAuthState)
@@ -177,7 +177,7 @@ class DriveState(rx.State):
             while done is False:
                 status, done = await rx.run_in_thread(downloader.next_chunk)
         except HttpError as error:
-            print(f"An error occurred: {error}")
+            print(f"An error occurred: {error}")  # noqa: T201
             file = None
         if file:
             file.seek(0)

--- a/google_auth_demo/requirements.txt
+++ b/google_auth_demo/requirements.txt
@@ -1,2 +1,3 @@
 reflex>=0.6.6
 reflex-google-auth
+google-api-python-client>=2.184.0


### PR DESCRIPTION
Allow interoperability with Google APIs by allowing the auth-code flow to request scopes that enable it to get a real access token that can be used to access google APIs on behalf of the authenticated user.

Updates the google_auth_demo to show how to request Drive scopes and update the hidden app data in the user's Drive.

demo deployed at https://google-auth-demo.reflex.run/custom-scope/